### PR TITLE
Add divxtotal indexer

### DIFF
--- a/src/Backup/Prowlarr.sln
+++ b/src/Backup/Prowlarr.sln
@@ -1,0 +1,320 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31912.275
+MinimumVisualStudioVersion = 15.0.26124.0
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Tests", "Tests", "{57A04B72-8088-4F75-A582-1158CF8291F7}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Test.Common", "Test.Common", "{47697CDB-27B6-4B05-B4F8-0CBE6F6EDF97}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "WindowsServiceHelpers", "WindowsServiceHelpers", "{F9E67978-5CD6-4A5F-827B-4249711C0B02}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Host", "Host", "{486ADF86-DD89-4E19-B805-9D94F19800D9}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Platform", "Platform", "{0F0D4998-8F5D-4467-A909-BB192C4B3B4B}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Platform", "Platform", "{4EACDBBC-BCD7-4765-A57B-3E08331E4749}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Prowlarr.Http", "Prowlarr.Http\Prowlarr.Http.csproj", "{F8A02FD4-A7A4-40D0-BB81-6319105A3302}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Prowlarr.Automation.Test", "NzbDrone.Automation.Test\Prowlarr.Automation.Test.csproj", "{2356C987-F992-4084-9DA2-5DAD1DA35E85}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Prowlarr.Common.Test", "NzbDrone.Common.Test\Prowlarr.Common.Test.csproj", "{A628FEA4-75CC-4039-8823-27258C55D2BF}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Prowlarr.Common", "NzbDrone.Common\Prowlarr.Common.csproj", "{74BF1D46-710C-42C1-82DD-34B42C58F843}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Prowlarr.Console", "NzbDrone.Console\Prowlarr.Console.csproj", "{AEA9EE9A-19BF-45CB-93D9-52CA443FD313}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Prowlarr.Core.Test", "NzbDrone.Core.Test\Prowlarr.Core.Test.csproj", "{04ECC74F-C340-4987-863E-757FB62D27C9}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Prowlarr.Core", "NzbDrone.Core\Prowlarr.Core.csproj", "{82EBE37B-E3A7-4365-9B06-FA647BCC7AF0}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Prowlarr.Host.Test", "NzbDrone.Host.Test\Prowlarr.Host.Test.csproj", "{6D4DE6D5-9594-4AE4-85E0-41C7FFCCED92}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Prowlarr.Host", "NzbDrone.Host\Prowlarr.Host.csproj", "{B6913970-FB88-4F6F-83F9-00728218E3FD}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Prowlarr.Integration.Test", "NzbDrone.Integration.Test\Prowlarr.Integration.Test.csproj", "{6D5618FB-45B9-44AE-BF99-8EF37519CB30}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Prowlarr.Libraries.Test", "NzbDrone.Libraries.Test\Prowlarr.Libraries.Test.csproj", "{1969394D-3181-404F-8E2C-E3E71A5BAD30}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Prowlarr.Mono.Test", "NzbDrone.Mono.Test\Prowlarr.Mono.Test.csproj", "{CCE9ABBC-96BA-425B-8140-DC8102290BE3}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Prowlarr.Mono", "NzbDrone.Mono\Prowlarr.Mono.csproj", "{504CD0A8-523B-4A0E-99BE-C179DECA9B76}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Prowlarr.SignalR", "NzbDrone.SignalR\Prowlarr.SignalR.csproj", "{B30BE76E-4D20-47AA-9E03-E32613D888CC}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Prowlarr.Test.Common", "NzbDrone.Test.Common\Prowlarr.Test.Common.csproj", "{B8706292-5BE8-4099-94CA-F26DDD3757E0}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Prowlarr.Test.Dummy", "NzbDrone.Test.Dummy\Prowlarr.Test.Dummy.csproj", "{AFA7F48E-DB81-4E39-843B-78715C6ADF0D}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Prowlarr.Update.Test", "NzbDrone.Update.Test\Prowlarr.Update.Test.csproj", "{A76441EE-AB2E-4E9D-8CD3-58BE5A8514D3}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Prowlarr.Update", "NzbDrone.Update\Prowlarr.Update.csproj", "{4FBA2CBC-B022-41D6-B6DA-3166991B9172}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Prowlarr.Windows.Test", "NzbDrone.Windows.Test\Prowlarr.Windows.Test.csproj", "{7BEDCC1E-0763-4553-B32B-0430B334ACBB}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Prowlarr.Windows", "NzbDrone.Windows\Prowlarr.Windows.csproj", "{3F076242-A6FA-4657-8606-AF1D150367FC}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Prowlarr", "NzbDrone\Prowlarr.csproj", "{0DC43D36-6680-4237-BE39-D5D094DBCE29}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ServiceInstall", "ServiceHelpers\ServiceInstall\ServiceInstall.csproj", "{7DA231E8-A31D-4F53-8760-820861B6CE65}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ServiceUninstall", "ServiceHelpers\ServiceUninstall\ServiceUninstall.csproj", "{0E2B067C-4A97-430C-8767-D19ACB09A63A}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{0C7E5F5A-C4CC-4945-B399-1E1C9817CC45}"
+	ProjectSection(SolutionItems) = preProject
+		..\.editorconfig = ..\.editorconfig
+	EndProjectSection
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Prowlarr.Api.V1", "Prowlarr.Api.V1\Prowlarr.Api.V1.csproj", "{022C0458-02DD-4D14-AF0E-F2FB87806A55}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Prowlarr.Api.V1.Test", "Prowlarr.Api.V1.Test\Prowlarr.Api.V1.Test.csproj", "{4EB5FDB5-5908-4415-8DFD-E5740A480D92}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Prowlarr.Benchmark.Test", "Prowlarr.Benchmark.Test\Prowlarr.Benchmark.Test.csproj", "{56B0D244-4791-40EE-8C01-08C34E3733B7}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Posix = Debug|Posix
+		Debug|Windows = Debug|Windows
+		Release|Posix = Release|Posix
+		Release|Windows = Release|Windows
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{F8A02FD4-A7A4-40D0-BB81-6319105A3302}.Debug|Posix.ActiveCfg = Debug|Any CPU
+		{F8A02FD4-A7A4-40D0-BB81-6319105A3302}.Debug|Posix.Build.0 = Debug|Any CPU
+		{F8A02FD4-A7A4-40D0-BB81-6319105A3302}.Debug|Windows.ActiveCfg = Debug|Any CPU
+		{F8A02FD4-A7A4-40D0-BB81-6319105A3302}.Debug|Windows.Build.0 = Debug|Any CPU
+		{F8A02FD4-A7A4-40D0-BB81-6319105A3302}.Release|Posix.ActiveCfg = Release|Any CPU
+		{F8A02FD4-A7A4-40D0-BB81-6319105A3302}.Release|Posix.Build.0 = Release|Any CPU
+		{F8A02FD4-A7A4-40D0-BB81-6319105A3302}.Release|Windows.ActiveCfg = Release|Any CPU
+		{F8A02FD4-A7A4-40D0-BB81-6319105A3302}.Release|Windows.Build.0 = Release|Any CPU
+		{2356C987-F992-4084-9DA2-5DAD1DA35E85}.Debug|Posix.ActiveCfg = Debug|Any CPU
+		{2356C987-F992-4084-9DA2-5DAD1DA35E85}.Debug|Posix.Build.0 = Debug|Any CPU
+		{2356C987-F992-4084-9DA2-5DAD1DA35E85}.Debug|Windows.ActiveCfg = Debug|Any CPU
+		{2356C987-F992-4084-9DA2-5DAD1DA35E85}.Debug|Windows.Build.0 = Debug|Any CPU
+		{2356C987-F992-4084-9DA2-5DAD1DA35E85}.Release|Posix.ActiveCfg = Release|Any CPU
+		{2356C987-F992-4084-9DA2-5DAD1DA35E85}.Release|Posix.Build.0 = Release|Any CPU
+		{2356C987-F992-4084-9DA2-5DAD1DA35E85}.Release|Windows.ActiveCfg = Release|Any CPU
+		{2356C987-F992-4084-9DA2-5DAD1DA35E85}.Release|Windows.Build.0 = Release|Any CPU
+		{A628FEA4-75CC-4039-8823-27258C55D2BF}.Debug|Posix.ActiveCfg = Debug|Any CPU
+		{A628FEA4-75CC-4039-8823-27258C55D2BF}.Debug|Posix.Build.0 = Debug|Any CPU
+		{A628FEA4-75CC-4039-8823-27258C55D2BF}.Debug|Windows.ActiveCfg = Debug|Any CPU
+		{A628FEA4-75CC-4039-8823-27258C55D2BF}.Debug|Windows.Build.0 = Debug|Any CPU
+		{A628FEA4-75CC-4039-8823-27258C55D2BF}.Release|Posix.ActiveCfg = Release|Any CPU
+		{A628FEA4-75CC-4039-8823-27258C55D2BF}.Release|Posix.Build.0 = Release|Any CPU
+		{A628FEA4-75CC-4039-8823-27258C55D2BF}.Release|Windows.ActiveCfg = Release|Any CPU
+		{A628FEA4-75CC-4039-8823-27258C55D2BF}.Release|Windows.Build.0 = Release|Any CPU
+		{74BF1D46-710C-42C1-82DD-34B42C58F843}.Debug|Posix.ActiveCfg = Debug|Any CPU
+		{74BF1D46-710C-42C1-82DD-34B42C58F843}.Debug|Posix.Build.0 = Debug|Any CPU
+		{74BF1D46-710C-42C1-82DD-34B42C58F843}.Debug|Windows.ActiveCfg = Debug|Any CPU
+		{74BF1D46-710C-42C1-82DD-34B42C58F843}.Debug|Windows.Build.0 = Debug|Any CPU
+		{74BF1D46-710C-42C1-82DD-34B42C58F843}.Release|Posix.ActiveCfg = Release|Any CPU
+		{74BF1D46-710C-42C1-82DD-34B42C58F843}.Release|Posix.Build.0 = Release|Any CPU
+		{74BF1D46-710C-42C1-82DD-34B42C58F843}.Release|Windows.ActiveCfg = Release|Any CPU
+		{74BF1D46-710C-42C1-82DD-34B42C58F843}.Release|Windows.Build.0 = Release|Any CPU
+		{AEA9EE9A-19BF-45CB-93D9-52CA443FD313}.Debug|Posix.ActiveCfg = Debug|Any CPU
+		{AEA9EE9A-19BF-45CB-93D9-52CA443FD313}.Debug|Posix.Build.0 = Debug|Any CPU
+		{AEA9EE9A-19BF-45CB-93D9-52CA443FD313}.Debug|Windows.ActiveCfg = Debug|Any CPU
+		{AEA9EE9A-19BF-45CB-93D9-52CA443FD313}.Debug|Windows.Build.0 = Debug|Any CPU
+		{AEA9EE9A-19BF-45CB-93D9-52CA443FD313}.Release|Posix.ActiveCfg = Release|Any CPU
+		{AEA9EE9A-19BF-45CB-93D9-52CA443FD313}.Release|Posix.Build.0 = Release|Any CPU
+		{AEA9EE9A-19BF-45CB-93D9-52CA443FD313}.Release|Windows.ActiveCfg = Release|Any CPU
+		{AEA9EE9A-19BF-45CB-93D9-52CA443FD313}.Release|Windows.Build.0 = Release|Any CPU
+		{04ECC74F-C340-4987-863E-757FB62D27C9}.Debug|Posix.ActiveCfg = Debug|Any CPU
+		{04ECC74F-C340-4987-863E-757FB62D27C9}.Debug|Posix.Build.0 = Debug|Any CPU
+		{04ECC74F-C340-4987-863E-757FB62D27C9}.Debug|Windows.ActiveCfg = Debug|Any CPU
+		{04ECC74F-C340-4987-863E-757FB62D27C9}.Debug|Windows.Build.0 = Debug|Any CPU
+		{04ECC74F-C340-4987-863E-757FB62D27C9}.Release|Posix.ActiveCfg = Release|Any CPU
+		{04ECC74F-C340-4987-863E-757FB62D27C9}.Release|Posix.Build.0 = Release|Any CPU
+		{04ECC74F-C340-4987-863E-757FB62D27C9}.Release|Windows.ActiveCfg = Release|Any CPU
+		{04ECC74F-C340-4987-863E-757FB62D27C9}.Release|Windows.Build.0 = Release|Any CPU
+		{82EBE37B-E3A7-4365-9B06-FA647BCC7AF0}.Debug|Posix.ActiveCfg = Debug|Any CPU
+		{82EBE37B-E3A7-4365-9B06-FA647BCC7AF0}.Debug|Posix.Build.0 = Debug|Any CPU
+		{82EBE37B-E3A7-4365-9B06-FA647BCC7AF0}.Debug|Windows.ActiveCfg = Debug|Any CPU
+		{82EBE37B-E3A7-4365-9B06-FA647BCC7AF0}.Debug|Windows.Build.0 = Debug|Any CPU
+		{82EBE37B-E3A7-4365-9B06-FA647BCC7AF0}.Release|Posix.ActiveCfg = Release|Any CPU
+		{82EBE37B-E3A7-4365-9B06-FA647BCC7AF0}.Release|Posix.Build.0 = Release|Any CPU
+		{82EBE37B-E3A7-4365-9B06-FA647BCC7AF0}.Release|Windows.ActiveCfg = Release|Any CPU
+		{82EBE37B-E3A7-4365-9B06-FA647BCC7AF0}.Release|Windows.Build.0 = Release|Any CPU
+		{6D4DE6D5-9594-4AE4-85E0-41C7FFCCED92}.Debug|Posix.ActiveCfg = Debug|Any CPU
+		{6D4DE6D5-9594-4AE4-85E0-41C7FFCCED92}.Debug|Posix.Build.0 = Debug|Any CPU
+		{6D4DE6D5-9594-4AE4-85E0-41C7FFCCED92}.Debug|Windows.ActiveCfg = Debug|Any CPU
+		{6D4DE6D5-9594-4AE4-85E0-41C7FFCCED92}.Debug|Windows.Build.0 = Debug|Any CPU
+		{6D4DE6D5-9594-4AE4-85E0-41C7FFCCED92}.Release|Posix.ActiveCfg = Release|Any CPU
+		{6D4DE6D5-9594-4AE4-85E0-41C7FFCCED92}.Release|Posix.Build.0 = Release|Any CPU
+		{6D4DE6D5-9594-4AE4-85E0-41C7FFCCED92}.Release|Windows.ActiveCfg = Release|Any CPU
+		{6D4DE6D5-9594-4AE4-85E0-41C7FFCCED92}.Release|Windows.Build.0 = Release|Any CPU
+		{B6913970-FB88-4F6F-83F9-00728218E3FD}.Debug|Posix.ActiveCfg = Debug|Any CPU
+		{B6913970-FB88-4F6F-83F9-00728218E3FD}.Debug|Posix.Build.0 = Debug|Any CPU
+		{B6913970-FB88-4F6F-83F9-00728218E3FD}.Debug|Windows.ActiveCfg = Debug|Any CPU
+		{B6913970-FB88-4F6F-83F9-00728218E3FD}.Debug|Windows.Build.0 = Debug|Any CPU
+		{B6913970-FB88-4F6F-83F9-00728218E3FD}.Release|Posix.ActiveCfg = Release|Any CPU
+		{B6913970-FB88-4F6F-83F9-00728218E3FD}.Release|Posix.Build.0 = Release|Any CPU
+		{B6913970-FB88-4F6F-83F9-00728218E3FD}.Release|Windows.ActiveCfg = Release|Any CPU
+		{B6913970-FB88-4F6F-83F9-00728218E3FD}.Release|Windows.Build.0 = Release|Any CPU
+		{6D5618FB-45B9-44AE-BF99-8EF37519CB30}.Debug|Posix.ActiveCfg = Debug|Any CPU
+		{6D5618FB-45B9-44AE-BF99-8EF37519CB30}.Debug|Posix.Build.0 = Debug|Any CPU
+		{6D5618FB-45B9-44AE-BF99-8EF37519CB30}.Debug|Windows.ActiveCfg = Debug|Any CPU
+		{6D5618FB-45B9-44AE-BF99-8EF37519CB30}.Debug|Windows.Build.0 = Debug|Any CPU
+		{6D5618FB-45B9-44AE-BF99-8EF37519CB30}.Release|Posix.ActiveCfg = Release|Any CPU
+		{6D5618FB-45B9-44AE-BF99-8EF37519CB30}.Release|Posix.Build.0 = Release|Any CPU
+		{6D5618FB-45B9-44AE-BF99-8EF37519CB30}.Release|Windows.ActiveCfg = Release|Any CPU
+		{6D5618FB-45B9-44AE-BF99-8EF37519CB30}.Release|Windows.Build.0 = Release|Any CPU
+		{1969394D-3181-404F-8E2C-E3E71A5BAD30}.Debug|Posix.ActiveCfg = Debug|Any CPU
+		{1969394D-3181-404F-8E2C-E3E71A5BAD30}.Debug|Posix.Build.0 = Debug|Any CPU
+		{1969394D-3181-404F-8E2C-E3E71A5BAD30}.Debug|Windows.ActiveCfg = Debug|Any CPU
+		{1969394D-3181-404F-8E2C-E3E71A5BAD30}.Debug|Windows.Build.0 = Debug|Any CPU
+		{1969394D-3181-404F-8E2C-E3E71A5BAD30}.Release|Posix.ActiveCfg = Release|Any CPU
+		{1969394D-3181-404F-8E2C-E3E71A5BAD30}.Release|Posix.Build.0 = Release|Any CPU
+		{1969394D-3181-404F-8E2C-E3E71A5BAD30}.Release|Windows.ActiveCfg = Release|Any CPU
+		{1969394D-3181-404F-8E2C-E3E71A5BAD30}.Release|Windows.Build.0 = Release|Any CPU
+		{CCE9ABBC-96BA-425B-8140-DC8102290BE3}.Debug|Posix.ActiveCfg = Debug|Any CPU
+		{CCE9ABBC-96BA-425B-8140-DC8102290BE3}.Debug|Posix.Build.0 = Debug|Any CPU
+		{CCE9ABBC-96BA-425B-8140-DC8102290BE3}.Debug|Windows.ActiveCfg = Debug|Any CPU
+		{CCE9ABBC-96BA-425B-8140-DC8102290BE3}.Debug|Windows.Build.0 = Debug|Any CPU
+		{CCE9ABBC-96BA-425B-8140-DC8102290BE3}.Release|Posix.ActiveCfg = Release|Any CPU
+		{CCE9ABBC-96BA-425B-8140-DC8102290BE3}.Release|Posix.Build.0 = Release|Any CPU
+		{CCE9ABBC-96BA-425B-8140-DC8102290BE3}.Release|Windows.ActiveCfg = Release|Any CPU
+		{CCE9ABBC-96BA-425B-8140-DC8102290BE3}.Release|Windows.Build.0 = Release|Any CPU
+		{504CD0A8-523B-4A0E-99BE-C179DECA9B76}.Debug|Posix.ActiveCfg = Debug|Any CPU
+		{504CD0A8-523B-4A0E-99BE-C179DECA9B76}.Debug|Posix.Build.0 = Debug|Any CPU
+		{504CD0A8-523B-4A0E-99BE-C179DECA9B76}.Debug|Windows.ActiveCfg = Debug|Any CPU
+		{504CD0A8-523B-4A0E-99BE-C179DECA9B76}.Debug|Windows.Build.0 = Debug|Any CPU
+		{504CD0A8-523B-4A0E-99BE-C179DECA9B76}.Release|Posix.ActiveCfg = Release|Any CPU
+		{504CD0A8-523B-4A0E-99BE-C179DECA9B76}.Release|Posix.Build.0 = Release|Any CPU
+		{504CD0A8-523B-4A0E-99BE-C179DECA9B76}.Release|Windows.ActiveCfg = Release|Any CPU
+		{504CD0A8-523B-4A0E-99BE-C179DECA9B76}.Release|Windows.Build.0 = Release|Any CPU
+		{B30BE76E-4D20-47AA-9E03-E32613D888CC}.Debug|Posix.ActiveCfg = Debug|Any CPU
+		{B30BE76E-4D20-47AA-9E03-E32613D888CC}.Debug|Posix.Build.0 = Debug|Any CPU
+		{B30BE76E-4D20-47AA-9E03-E32613D888CC}.Debug|Windows.ActiveCfg = Debug|Any CPU
+		{B30BE76E-4D20-47AA-9E03-E32613D888CC}.Debug|Windows.Build.0 = Debug|Any CPU
+		{B30BE76E-4D20-47AA-9E03-E32613D888CC}.Release|Posix.ActiveCfg = Release|Any CPU
+		{B30BE76E-4D20-47AA-9E03-E32613D888CC}.Release|Posix.Build.0 = Release|Any CPU
+		{B30BE76E-4D20-47AA-9E03-E32613D888CC}.Release|Windows.ActiveCfg = Release|Any CPU
+		{B30BE76E-4D20-47AA-9E03-E32613D888CC}.Release|Windows.Build.0 = Release|Any CPU
+		{B8706292-5BE8-4099-94CA-F26DDD3757E0}.Debug|Posix.ActiveCfg = Debug|Any CPU
+		{B8706292-5BE8-4099-94CA-F26DDD3757E0}.Debug|Posix.Build.0 = Debug|Any CPU
+		{B8706292-5BE8-4099-94CA-F26DDD3757E0}.Debug|Windows.ActiveCfg = Debug|Any CPU
+		{B8706292-5BE8-4099-94CA-F26DDD3757E0}.Debug|Windows.Build.0 = Debug|Any CPU
+		{B8706292-5BE8-4099-94CA-F26DDD3757E0}.Release|Posix.ActiveCfg = Release|Any CPU
+		{B8706292-5BE8-4099-94CA-F26DDD3757E0}.Release|Posix.Build.0 = Release|Any CPU
+		{B8706292-5BE8-4099-94CA-F26DDD3757E0}.Release|Windows.ActiveCfg = Release|Any CPU
+		{B8706292-5BE8-4099-94CA-F26DDD3757E0}.Release|Windows.Build.0 = Release|Any CPU
+		{AFA7F48E-DB81-4E39-843B-78715C6ADF0D}.Debug|Posix.ActiveCfg = Debug|Any CPU
+		{AFA7F48E-DB81-4E39-843B-78715C6ADF0D}.Debug|Posix.Build.0 = Debug|Any CPU
+		{AFA7F48E-DB81-4E39-843B-78715C6ADF0D}.Debug|Windows.ActiveCfg = Debug|Any CPU
+		{AFA7F48E-DB81-4E39-843B-78715C6ADF0D}.Debug|Windows.Build.0 = Debug|Any CPU
+		{AFA7F48E-DB81-4E39-843B-78715C6ADF0D}.Release|Posix.ActiveCfg = Release|Any CPU
+		{AFA7F48E-DB81-4E39-843B-78715C6ADF0D}.Release|Posix.Build.0 = Release|Any CPU
+		{AFA7F48E-DB81-4E39-843B-78715C6ADF0D}.Release|Windows.ActiveCfg = Release|Any CPU
+		{AFA7F48E-DB81-4E39-843B-78715C6ADF0D}.Release|Windows.Build.0 = Release|Any CPU
+		{A76441EE-AB2E-4E9D-8CD3-58BE5A8514D3}.Debug|Posix.ActiveCfg = Debug|Any CPU
+		{A76441EE-AB2E-4E9D-8CD3-58BE5A8514D3}.Debug|Posix.Build.0 = Debug|Any CPU
+		{A76441EE-AB2E-4E9D-8CD3-58BE5A8514D3}.Debug|Windows.ActiveCfg = Debug|Any CPU
+		{A76441EE-AB2E-4E9D-8CD3-58BE5A8514D3}.Debug|Windows.Build.0 = Debug|Any CPU
+		{A76441EE-AB2E-4E9D-8CD3-58BE5A8514D3}.Release|Posix.ActiveCfg = Release|Any CPU
+		{A76441EE-AB2E-4E9D-8CD3-58BE5A8514D3}.Release|Posix.Build.0 = Release|Any CPU
+		{A76441EE-AB2E-4E9D-8CD3-58BE5A8514D3}.Release|Windows.ActiveCfg = Release|Any CPU
+		{A76441EE-AB2E-4E9D-8CD3-58BE5A8514D3}.Release|Windows.Build.0 = Release|Any CPU
+		{4FBA2CBC-B022-41D6-B6DA-3166991B9172}.Debug|Posix.ActiveCfg = Debug|Any CPU
+		{4FBA2CBC-B022-41D6-B6DA-3166991B9172}.Debug|Posix.Build.0 = Debug|Any CPU
+		{4FBA2CBC-B022-41D6-B6DA-3166991B9172}.Debug|Windows.ActiveCfg = Debug|Any CPU
+		{4FBA2CBC-B022-41D6-B6DA-3166991B9172}.Debug|Windows.Build.0 = Debug|Any CPU
+		{4FBA2CBC-B022-41D6-B6DA-3166991B9172}.Release|Posix.ActiveCfg = Release|Any CPU
+		{4FBA2CBC-B022-41D6-B6DA-3166991B9172}.Release|Posix.Build.0 = Release|Any CPU
+		{4FBA2CBC-B022-41D6-B6DA-3166991B9172}.Release|Windows.ActiveCfg = Release|Any CPU
+		{4FBA2CBC-B022-41D6-B6DA-3166991B9172}.Release|Windows.Build.0 = Release|Any CPU
+		{7BEDCC1E-0763-4553-B32B-0430B334ACBB}.Debug|Posix.ActiveCfg = Debug|Any CPU
+		{7BEDCC1E-0763-4553-B32B-0430B334ACBB}.Debug|Posix.Build.0 = Debug|Any CPU
+		{7BEDCC1E-0763-4553-B32B-0430B334ACBB}.Debug|Windows.ActiveCfg = Debug|Any CPU
+		{7BEDCC1E-0763-4553-B32B-0430B334ACBB}.Debug|Windows.Build.0 = Debug|Any CPU
+		{7BEDCC1E-0763-4553-B32B-0430B334ACBB}.Release|Posix.ActiveCfg = Release|Any CPU
+		{7BEDCC1E-0763-4553-B32B-0430B334ACBB}.Release|Posix.Build.0 = Release|Any CPU
+		{7BEDCC1E-0763-4553-B32B-0430B334ACBB}.Release|Windows.ActiveCfg = Release|Any CPU
+		{7BEDCC1E-0763-4553-B32B-0430B334ACBB}.Release|Windows.Build.0 = Release|Any CPU
+		{3F076242-A6FA-4657-8606-AF1D150367FC}.Debug|Posix.ActiveCfg = Debug|Any CPU
+		{3F076242-A6FA-4657-8606-AF1D150367FC}.Debug|Posix.Build.0 = Debug|Any CPU
+		{3F076242-A6FA-4657-8606-AF1D150367FC}.Debug|Windows.ActiveCfg = Debug|Any CPU
+		{3F076242-A6FA-4657-8606-AF1D150367FC}.Debug|Windows.Build.0 = Debug|Any CPU
+		{3F076242-A6FA-4657-8606-AF1D150367FC}.Release|Posix.ActiveCfg = Release|Any CPU
+		{3F076242-A6FA-4657-8606-AF1D150367FC}.Release|Posix.Build.0 = Release|Any CPU
+		{3F076242-A6FA-4657-8606-AF1D150367FC}.Release|Windows.ActiveCfg = Release|Any CPU
+		{3F076242-A6FA-4657-8606-AF1D150367FC}.Release|Windows.Build.0 = Release|Any CPU
+		{0DC43D36-6680-4237-BE39-D5D094DBCE29}.Debug|Posix.ActiveCfg = Debug|Any CPU
+		{0DC43D36-6680-4237-BE39-D5D094DBCE29}.Debug|Windows.ActiveCfg = Debug|Any CPU
+		{0DC43D36-6680-4237-BE39-D5D094DBCE29}.Debug|Windows.Build.0 = Debug|Any CPU
+		{0DC43D36-6680-4237-BE39-D5D094DBCE29}.Release|Posix.ActiveCfg = Release|Any CPU
+		{0DC43D36-6680-4237-BE39-D5D094DBCE29}.Release|Windows.ActiveCfg = Release|Any CPU
+		{0DC43D36-6680-4237-BE39-D5D094DBCE29}.Release|Windows.Build.0 = Release|Any CPU
+		{7DA231E8-A31D-4F53-8760-820861B6CE65}.Debug|Posix.ActiveCfg = Debug|Any CPU
+		{7DA231E8-A31D-4F53-8760-820861B6CE65}.Debug|Posix.Build.0 = Debug|Any CPU
+		{7DA231E8-A31D-4F53-8760-820861B6CE65}.Debug|Windows.ActiveCfg = Debug|Any CPU
+		{7DA231E8-A31D-4F53-8760-820861B6CE65}.Debug|Windows.Build.0 = Debug|Any CPU
+		{7DA231E8-A31D-4F53-8760-820861B6CE65}.Release|Posix.ActiveCfg = Release|Any CPU
+		{7DA231E8-A31D-4F53-8760-820861B6CE65}.Release|Posix.Build.0 = Release|Any CPU
+		{7DA231E8-A31D-4F53-8760-820861B6CE65}.Release|Windows.ActiveCfg = Release|Any CPU
+		{7DA231E8-A31D-4F53-8760-820861B6CE65}.Release|Windows.Build.0 = Release|Any CPU
+		{0E2B067C-4A97-430C-8767-D19ACB09A63A}.Debug|Posix.ActiveCfg = Debug|Any CPU
+		{0E2B067C-4A97-430C-8767-D19ACB09A63A}.Debug|Posix.Build.0 = Debug|Any CPU
+		{0E2B067C-4A97-430C-8767-D19ACB09A63A}.Debug|Windows.ActiveCfg = Debug|Any CPU
+		{0E2B067C-4A97-430C-8767-D19ACB09A63A}.Debug|Windows.Build.0 = Debug|Any CPU
+		{0E2B067C-4A97-430C-8767-D19ACB09A63A}.Release|Posix.ActiveCfg = Release|Any CPU
+		{0E2B067C-4A97-430C-8767-D19ACB09A63A}.Release|Posix.Build.0 = Release|Any CPU
+		{0E2B067C-4A97-430C-8767-D19ACB09A63A}.Release|Windows.ActiveCfg = Release|Any CPU
+		{0E2B067C-4A97-430C-8767-D19ACB09A63A}.Release|Windows.Build.0 = Release|Any CPU
+		{022C0458-02DD-4D14-AF0E-F2FB87806A55}.Debug|Posix.ActiveCfg = Debug|Any CPU
+		{022C0458-02DD-4D14-AF0E-F2FB87806A55}.Debug|Posix.Build.0 = Debug|Any CPU
+		{022C0458-02DD-4D14-AF0E-F2FB87806A55}.Debug|Windows.ActiveCfg = Debug|Any CPU
+		{022C0458-02DD-4D14-AF0E-F2FB87806A55}.Debug|Windows.Build.0 = Debug|Any CPU
+		{022C0458-02DD-4D14-AF0E-F2FB87806A55}.Release|Posix.ActiveCfg = Release|Any CPU
+		{022C0458-02DD-4D14-AF0E-F2FB87806A55}.Release|Posix.Build.0 = Release|Any CPU
+		{022C0458-02DD-4D14-AF0E-F2FB87806A55}.Release|Windows.ActiveCfg = Release|Any CPU
+		{022C0458-02DD-4D14-AF0E-F2FB87806A55}.Release|Windows.Build.0 = Release|Any CPU
+		{4EB5FDB5-5908-4415-8DFD-E5740A480D92}.Debug|Posix.ActiveCfg = Debug|Any CPU
+		{4EB5FDB5-5908-4415-8DFD-E5740A480D92}.Debug|Posix.Build.0 = Debug|Any CPU
+		{4EB5FDB5-5908-4415-8DFD-E5740A480D92}.Debug|Windows.ActiveCfg = Debug|Any CPU
+		{4EB5FDB5-5908-4415-8DFD-E5740A480D92}.Debug|Windows.Build.0 = Debug|Any CPU
+		{4EB5FDB5-5908-4415-8DFD-E5740A480D92}.Release|Posix.ActiveCfg = Release|Any CPU
+		{4EB5FDB5-5908-4415-8DFD-E5740A480D92}.Release|Posix.Build.0 = Release|Any CPU
+		{4EB5FDB5-5908-4415-8DFD-E5740A480D92}.Release|Windows.ActiveCfg = Release|Any CPU
+		{4EB5FDB5-5908-4415-8DFD-E5740A480D92}.Release|Windows.Build.0 = Release|Any CPU
+		{56B0D244-4791-40EE-8C01-08C34E3733B7}.Debug|Posix.ActiveCfg = Debug|Any CPU
+		{56B0D244-4791-40EE-8C01-08C34E3733B7}.Debug|Posix.Build.0 = Debug|Any CPU
+		{56B0D244-4791-40EE-8C01-08C34E3733B7}.Debug|Windows.ActiveCfg = Debug|Any CPU
+		{56B0D244-4791-40EE-8C01-08C34E3733B7}.Debug|Windows.Build.0 = Debug|Any CPU
+		{56B0D244-4791-40EE-8C01-08C34E3733B7}.Release|Posix.ActiveCfg = Release|Any CPU
+		{56B0D244-4791-40EE-8C01-08C34E3733B7}.Release|Posix.Build.0 = Release|Any CPU
+		{56B0D244-4791-40EE-8C01-08C34E3733B7}.Release|Windows.ActiveCfg = Release|Any CPU
+		{56B0D244-4791-40EE-8C01-08C34E3733B7}.Release|Windows.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{47697CDB-27B6-4B05-B4F8-0CBE6F6EDF97} = {57A04B72-8088-4F75-A582-1158CF8291F7}
+		{4EACDBBC-BCD7-4765-A57B-3E08331E4749} = {57A04B72-8088-4F75-A582-1158CF8291F7}
+		{2356C987-F992-4084-9DA2-5DAD1DA35E85} = {57A04B72-8088-4F75-A582-1158CF8291F7}
+		{A628FEA4-75CC-4039-8823-27258C55D2BF} = {57A04B72-8088-4F75-A582-1158CF8291F7}
+		{AEA9EE9A-19BF-45CB-93D9-52CA443FD313} = {486ADF86-DD89-4E19-B805-9D94F19800D9}
+		{04ECC74F-C340-4987-863E-757FB62D27C9} = {57A04B72-8088-4F75-A582-1158CF8291F7}
+		{6D4DE6D5-9594-4AE4-85E0-41C7FFCCED92} = {57A04B72-8088-4F75-A582-1158CF8291F7}
+		{B6913970-FB88-4F6F-83F9-00728218E3FD} = {486ADF86-DD89-4E19-B805-9D94F19800D9}
+		{6D5618FB-45B9-44AE-BF99-8EF37519CB30} = {57A04B72-8088-4F75-A582-1158CF8291F7}
+		{1969394D-3181-404F-8E2C-E3E71A5BAD30} = {57A04B72-8088-4F75-A582-1158CF8291F7}
+		{CCE9ABBC-96BA-425B-8140-DC8102290BE3} = {4EACDBBC-BCD7-4765-A57B-3E08331E4749}
+		{504CD0A8-523B-4A0E-99BE-C179DECA9B76} = {0F0D4998-8F5D-4467-A909-BB192C4B3B4B}
+		{B8706292-5BE8-4099-94CA-F26DDD3757E0} = {47697CDB-27B6-4B05-B4F8-0CBE6F6EDF97}
+		{AFA7F48E-DB81-4E39-843B-78715C6ADF0D} = {47697CDB-27B6-4B05-B4F8-0CBE6F6EDF97}
+		{A76441EE-AB2E-4E9D-8CD3-58BE5A8514D3} = {57A04B72-8088-4F75-A582-1158CF8291F7}
+		{7BEDCC1E-0763-4553-B32B-0430B334ACBB} = {4EACDBBC-BCD7-4765-A57B-3E08331E4749}
+		{3F076242-A6FA-4657-8606-AF1D150367FC} = {0F0D4998-8F5D-4467-A909-BB192C4B3B4B}
+		{0DC43D36-6680-4237-BE39-D5D094DBCE29} = {486ADF86-DD89-4E19-B805-9D94F19800D9}
+		{7DA231E8-A31D-4F53-8760-820861B6CE65} = {F9E67978-5CD6-4A5F-827B-4249711C0B02}
+		{0E2B067C-4A97-430C-8767-D19ACB09A63A} = {F9E67978-5CD6-4A5F-827B-4249711C0B02}
+		{4EB5FDB5-5908-4415-8DFD-E5740A480D92} = {57A04B72-8088-4F75-A582-1158CF8291F7}
+		{56B0D244-4791-40EE-8C01-08C34E3733B7} = {57A04B72-8088-4F75-A582-1158CF8291F7}
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {0D6944ED-0602-492F-9E11-0513294A4DA3}
+	EndGlobalSection
+EndGlobal

--- a/src/NzbDrone.Core/Indexers/Definitions/DivxTotal/DivxTotal.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/DivxTotal/DivxTotal.cs
@@ -1,0 +1,251 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+using NLog;
+using NzbDrone.Common.Extensions;
+using NzbDrone.Common.Http;
+using NzbDrone.Core.Configuration;
+using NzbDrone.Core.Http.CloudFlare;
+using NzbDrone.Core.Indexers.Exceptions;
+using NzbDrone.Core.IndexerSearch.Definitions;
+using NzbDrone.Core.Messaging.Events;
+using NzbDrone.Core.Parser.Model;
+
+namespace NzbDrone.Core.Indexers.Definitions.DivxTotal
+{
+    public class DivxTotal : TorrentIndexerBase<DivxTotalSettings>
+    {
+        public override string Name => "DivxTotal";
+        public override string[] IndexerUrls => new[] { "https://www5.divxtotal.mov/" };
+        public override string Description => "DivxTotal is a SPANISH site for Movies, TV series and Software";
+        public override string Language => "es-ES";
+        public override Encoding Encoding => Encoding.UTF8;
+        public override IndexerPrivacy Privacy => IndexerPrivacy.Public;
+        public override IndexerCapabilities Capabilities => SetCapabilities();
+
+        public override int PageSize => 15;
+
+        public DivxTotal(IIndexerHttpClient httpClient,
+            IEventAggregator eventAggregator,
+            IIndexerStatusService indexerStatusService,
+            IConfigService configService,
+            Logger logger)
+            : base(httpClient, eventAggregator, indexerStatusService, configService, logger)
+        {
+        }
+
+        public override IIndexerRequestGenerator GetRequestGenerator()
+        {
+            return new DivxTotalRequestGenerator(Settings, Capabilities);
+        }
+
+        public override IParseIndexerResponse GetParser()
+        {
+            return new DivxTotalParser(Settings, Capabilities.Categories);
+        }
+
+        protected IParseIndexerResponse getSeriesParser()
+        {
+            return new DivxTotalSeriesParser(Settings, Capabilities.Categories);
+        }
+
+        protected override async Task<IndexerPageableQueryResult> FetchReleases(Func<IIndexerRequestGenerator, IndexerPageableRequestChain> pageableRequestChainSelector, SearchCriteriaBase searchCriteria, bool isRecent = false)
+        {
+            var releases = new List<ReleaseInfo>();
+            var result = new IndexerPageableQueryResult();
+            var url = string.Empty;
+            var minimumBackoff = TimeSpan.FromHours(1);
+
+            try
+            {
+                var generator = GetRequestGenerator();
+                var parser = GetParser();
+                var seriesParser = getSeriesParser();
+                parser.CookiesUpdater = (cookies, expiration) =>
+                {
+                    _indexerStatusService.UpdateCookies(Definition.Id, cookies, expiration);
+                };
+
+                var pageableRequestChain = pageableRequestChainSelector(generator);
+
+                for (var i = 0; i < pageableRequestChain.Tiers; i++)
+                {
+                    var pageableRequests = pageableRequestChain.GetTier(i);
+
+                    foreach (var pageableRequest in pageableRequests)
+                    {
+                        var pagedReleases = new List<ReleaseInfo>();
+
+                        var pageSize = PageSize;
+
+                        foreach (var request in pageableRequest)
+                        {
+                            url = request.Url.FullUri;
+
+                            var page = await FetchPage(request, parser);
+
+                            var filteredPage = new IndexerQueryResult();
+
+                            // Sadly, releases are partial at this point if the result was a series, since DivxTotal does not have meaningful info at the search level
+                            // They also aren´t filtered by category, so we need to filter them here and remove them.
+                            for (var j = page.Releases.Count - 1; j >= 0; j--)
+                            {
+                                // return results only for requested categories
+                                if (searchCriteria.Categories.Any() && !searchCriteria.Categories.Any(c => page.Releases[j].Categories.Any(cat => cat.Id == c)))
+                                {
+                                    page.Releases.RemoveAt(j);
+                                    continue;
+                                }
+
+                                if (searchCriteria is BasicSearchCriteria or TvSearchCriteria || string.IsNullOrWhiteSpace(page.Releases[j].DownloadUrl))
+                                {
+                                    // Fetch the info page for the release
+                                    var info = await FetchPage(new IndexerRequest(page.Releases[j].InfoUrl, HttpAccept.Html), getSeriesParser());
+                                    pagedReleases.AddRange(info.Releases);
+                                    page.Releases.RemoveAt(i);
+                                }
+                            }
+
+                            pageSize = pageSize == 1 ? page.Releases.Count : pageSize;
+
+                            result.Queries.Add(page);
+
+                            pagedReleases.AddRange(page.Releases);
+
+                            if (!IsFullPage(page.Releases, pageSize))
+                            {
+                                break;
+                            }
+                        }
+
+                        releases.AddRange(pagedReleases.Where(r => IsValidRelease(r, searchCriteria.InteractiveSearch)));
+                    }
+
+                    if (releases.Any())
+                    {
+                        break;
+                    }
+                }
+
+                _indexerStatusService.RecordSuccess(Definition.Id);
+            }
+            catch (WebException webException)
+            {
+                if (webException.Status is WebExceptionStatus.NameResolutionFailure or WebExceptionStatus.ConnectFailure)
+                {
+                    _indexerStatusService.RecordConnectionFailure(Definition.Id);
+                }
+                else
+                {
+                    _indexerStatusService.RecordFailure(Definition.Id);
+                }
+
+                if (webException.Message.Contains("502") || webException.Message.Contains("503") ||
+                    webException.Message.Contains("504") || webException.Message.Contains("timed out"))
+                {
+                    _logger.Warn(webException, "{0} server is currently unavailable. {1} {2}", this, url, webException.Message);
+                }
+                else
+                {
+                    _logger.Warn(webException, "{0} {1} {2}", this, url, webException.Message);
+                }
+            }
+            catch (TooManyRequestsException ex)
+            {
+                result.Queries.Add(new IndexerQueryResult { Response = ex.Response });
+
+                var retryTime = ex.RetryAfter != TimeSpan.Zero ? ex.RetryAfter : minimumBackoff;
+
+                _indexerStatusService.RecordFailure(Definition.Id, retryTime);
+                _logger.Warn(ex, "Request Limit reached for {0}. Disabled for {1}", this, retryTime);
+            }
+            catch (HttpException ex)
+            {
+                result.Queries.Add(new IndexerQueryResult { Response = ex.Response });
+                _indexerStatusService.RecordFailure(Definition.Id);
+
+                if (ex.Response.HasHttpServerError)
+                {
+                    _logger.Warn(ex, "Unable to connect to {0} at [{1}]. Indexer's server is unavailable. Try again later. {2}", this, url, ex.Message);
+                }
+                else
+                {
+                    _logger.Warn(ex, "{0} {1}", this, ex.Message);
+                }
+            }
+            catch (RequestLimitReachedException ex)
+            {
+                result.Queries.Add(new IndexerQueryResult { Response = ex.Response.HttpResponse });
+                _indexerStatusService.RecordFailure(Definition.Id, minimumBackoff);
+                _logger.Warn(ex, "Request Limit reached for {0}. Disabled for {1}", this, minimumBackoff);
+            }
+            catch (IndexerAuthException ex)
+            {
+                _indexerStatusService.RecordFailure(Definition.Id);
+                _logger.Warn(ex, "Invalid Credentials for {0} {1}", this, url);
+            }
+            catch (CloudFlareProtectionException ex)
+            {
+                result.Queries.Add(new IndexerQueryResult { Response = ex.Response });
+                _indexerStatusService.RecordFailure(Definition.Id);
+                ex.WithData("FeedUrl", url);
+                _logger.Error(ex, "Cloudflare protection detected for {0}, Flaresolverr may be required.", this);
+            }
+            catch (IndexerException ex)
+            {
+                result.Queries.Add(new IndexerQueryResult { Response = ex.Response.HttpResponse });
+                _indexerStatusService.RecordFailure(Definition.Id);
+                _logger.Warn(ex, "{0}", url);
+            }
+            catch (HttpRequestException ex)
+            {
+                _indexerStatusService.RecordFailure(Definition.Id);
+                _logger.Warn(ex, "Unable to connect to indexer, please check your DNS settings and ensure IPv6 is working or disabled. {0}", url);
+            }
+            catch (TaskCanceledException ex)
+            {
+                _indexerStatusService.RecordFailure(Definition.Id);
+                _logger.Warn(ex, "Unable to connect to indexer, possibly due to a timeout. {0}", url);
+            }
+            catch (Exception ex)
+            {
+                _indexerStatusService.RecordFailure(Definition.Id);
+                ex.WithData("FeedUrl", url);
+                _logger.Error(ex, "An error occurred while processing indexer feed. {0}", url);
+            }
+
+            result.Releases = CleanupReleases(releases, searchCriteria);
+
+            return result;
+        }
+
+        private IndexerCapabilities SetCapabilities()
+        {
+            var caps = new IndexerCapabilities
+            {
+                TvSearchParams = new List<TvSearchParam>
+                {
+                    TvSearchParam.Q, TvSearchParam.Season, TvSearchParam.Ep
+                },
+                MovieSearchParams = new List<MovieSearchParam>
+                {
+                    MovieSearchParam.Q,
+                },
+            };
+
+            caps.Categories.AddCategoryMapping(DivxTotalCategories.Peliculas, NewznabStandardCategory.MoviesSD, "Películas");
+            caps.Categories.AddCategoryMapping(DivxTotalCategories.PeliculasHd, NewznabStandardCategory.MoviesHD, "Películas HD");
+            caps.Categories.AddCategoryMapping(DivxTotalCategories.Peliculas3D, NewznabStandardCategory.Movies3D, "Películas 3D");
+            caps.Categories.AddCategoryMapping(DivxTotalCategories.PeliculasDvdr, NewznabStandardCategory.MoviesDVD, "Películas DVD-r");
+            caps.Categories.AddCategoryMapping(DivxTotalCategories.Series, NewznabStandardCategory.TVSD, "Series");
+            caps.Categories.AddCategoryMapping(DivxTotalCategories.Programas, NewznabStandardCategory.PC, "Programas");
+            caps.Categories.AddCategoryMapping(DivxTotalCategories.Otros, NewznabStandardCategory.OtherMisc, "Otros");
+
+            return caps;
+        }
+    }
+}

--- a/src/NzbDrone.Core/Indexers/Definitions/DivxTotal/DivxTotal.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/DivxTotal/DivxTotal.cs
@@ -110,8 +110,6 @@ namespace NzbDrone.Core.Indexers.Definitions.DivxTotal
                                 }
                             }
 
-                            pageSize = pageSize == 1 ? page.Releases.Count : pageSize;
-
                             result.Queries.Add(page);
 
                             pagedReleases.AddRange(page.Releases);

--- a/src/NzbDrone.Core/Indexers/Definitions/DivxTotal/DivxTotalParser.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/DivxTotal/DivxTotalParser.cs
@@ -1,0 +1,97 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Net;
+using AngleSharp.Html.Parser;
+using NzbDrone.Core.Indexers.Exceptions;
+using NzbDrone.Core.Parser;
+using NzbDrone.Core.Parser.Model;
+
+namespace NzbDrone.Core.Indexers.Definitions.DivxTotal
+{
+    public class DivxTotalParser : IParseIndexerResponse
+    {
+        private readonly DivxTotalSettings _settings;
+        private readonly IndexerCapabilitiesCategories _categories;
+
+        public DivxTotalParser(DivxTotalSettings settings, IndexerCapabilitiesCategories categories)
+        {
+            _settings = settings;
+            _categories = categories;
+        }
+
+        public IList<ReleaseInfo> ParseResponse(IndexerResponse indexerResponse)
+        {
+            if (indexerResponse.HttpResponse.StatusCode != HttpStatusCode.OK)
+            {
+                throw new IndexerException(indexerResponse, $"Anidex search returned unexpected result. Expected 200 OK but got {indexerResponse.HttpResponse.StatusCode}.");
+            }
+
+            var releaseInfos = new List<ReleaseInfo>();
+
+            var parser = new HtmlParser();
+            using var dom = parser.ParseDocument(indexerResponse.Content);
+
+            var rows = dom.QuerySelectorAll("table.table > tbody > tr");
+            foreach (var row in rows)
+            {
+                var anchor = row.QuerySelector("a");
+                var title = anchor.TextContent.Trim();
+
+                var detailsStr = anchor.GetAttribute("href");
+                var cat = detailsStr.Split("/")[3];
+
+                var publishStr = row.QuerySelectorAll("td")[2].TextContent.Trim();
+                var publishDate = TryToParseDate(publishStr, DateTime.Now);
+                var sizeStr = row.QuerySelectorAll("td")[3].TextContent.Trim();
+
+                var release = new TorrentInfo
+                {
+                    Guid = detailsStr,
+                    InfoUrl = detailsStr,
+                    DownloadUrl = $"{(cat != DivxTotalCategories.Series ? detailsStr : "")}",
+                    Title = title,
+                    Categories = _categories.MapTrackerCatToNewznab(cat),
+                    PublishDate = publishDate,
+                    Files = 1,
+                    Seeders = 1,
+                    Peers = 2,
+                    Size = TryToParseSize(sizeStr, DivxTotalFizeSizes.Otros),
+                    DownloadVolumeFactor = 0,
+                    UploadVolumeFactor = 1
+                };
+
+                releaseInfos.Add(release);
+            }
+
+            return releaseInfos.ToArray();
+        }
+
+        private static DateTime TryToParseDate(string dateToParse, DateTime dateDefault)
+        {
+            try
+            {
+                return DateTime.ParseExact(dateToParse, "dd-MM-yyyy", CultureInfo.InvariantCulture);
+            }
+            catch
+            {
+                return dateDefault;
+            }
+        }
+
+        private static long TryToParseSize(string sizeToParse, long sizeDefault)
+        {
+            try
+            {
+                var parsedSize = ParseUtil.GetBytes(sizeToParse);
+                return parsedSize > 0 ? parsedSize : sizeDefault;
+            }
+            catch
+            {
+                return sizeDefault;
+            }
+        }
+
+        public Action<IDictionary<string, string>, DateTime?> CookiesUpdater { get; set; }
+    }
+}

--- a/src/NzbDrone.Core/Indexers/Definitions/DivxTotal/DivxTotalRequestGenerator.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/DivxTotal/DivxTotalRequestGenerator.cs
@@ -1,0 +1,105 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Specialized;
+using System.Text.RegularExpressions;
+using NzbDrone.Common.Http;
+using NzbDrone.Core.IndexerSearch.Definitions;
+using NzbDrone.Core.Parser;
+
+namespace NzbDrone.Core.Indexers.Definitions.DivxTotal
+{
+    public class DivxTotalRequestGenerator : IIndexerRequestGenerator
+    {
+        private readonly DivxTotalSettings _settings;
+        private readonly IndexerCapabilities _capabilities;
+
+        public DivxTotalRequestGenerator(DivxTotalSettings settings, IndexerCapabilities capabilities)
+        {
+            _settings = settings;
+            _capabilities = capabilities;
+        }
+
+        public IndexerPageableRequestChain GetSearchRequests(MovieSearchCriteria searchCriteria)
+        {
+            var pageableRequests = new IndexerPageableRequestChain();
+
+            pageableRequests.Add(GetPagedRequests($"{searchCriteria.SanitizedSearchTerm}"));
+
+            return pageableRequests;
+        }
+
+        public IndexerPageableRequestChain GetSearchRequests(MusicSearchCriteria searchCriteria)
+        {
+            return new IndexerPageableRequestChain();
+        }
+
+        public IndexerPageableRequestChain GetSearchRequests(TvSearchCriteria searchCriteria)
+        {
+            var pageableRequests = new IndexerPageableRequestChain();
+
+            pageableRequests.Add(GetPagedRequests($"{searchCriteria.SanitizedTvSearchString}", "/series-6"));
+
+            return pageableRequests;
+        }
+
+        public IndexerPageableRequestChain GetSearchRequests(BookSearchCriteria searchCriteria)
+        {
+            return new IndexerPageableRequestChain();
+        }
+
+        public IndexerPageableRequestChain GetSearchRequests(BasicSearchCriteria searchCriteria)
+        {
+            var pageableRequests = new IndexerPageableRequestChain();
+
+            pageableRequests.Add(GetPagedRequests($"{searchCriteria.SanitizedSearchTerm}"));
+
+            return pageableRequests;
+        }
+
+        private IEnumerable<IndexerRequest> GetPagedRequests(string term, string sub = "")
+        {
+            var parameters = new NameValueCollection
+            {
+                { "s", Sanitize(term) ?? string.Empty }
+            };
+
+            var i = 0;
+            do
+            {
+                i++;
+                var searchUrl = $"{_settings.BaseUrl}{sub}/page/{i}?{parameters.GetQueryString()}";
+
+                var request = new IndexerRequest(searchUrl, HttpAccept.Html);
+
+                yield return request;
+            }
+            while (true);
+        }
+
+        public Func<IDictionary<string, string>> GetCookies { get; set; }
+        public Action<IDictionary<string, string>, DateTime?> CookiesUpdater { get; set; }
+
+        private static string Sanitize(string term)
+        {
+            // replace punctuation symbols with spaces
+            // searchTerm = Marco Polo 2014
+            term = Regex.Replace(term, @"[-._\(\)@/\\\[\]\+\%]", " ");
+            term = Regex.Replace(term, @"\s+", " ");
+            term = term.Trim();
+
+            // we parse the year and remove it from search
+            // searchTerm = Marco Polo
+            // query.Year = 2014
+            var r = new Regex("([ ]+([0-9]{4}))$", RegexOptions.IgnoreCase);
+            var m = r.Match(term);
+            if (m.Success)
+            {
+                term = term.Replace(m.Groups[1].Value, "");
+            }
+
+            term = Regex.Replace(term, @"\b(espa[ñn]ol|spanish|castellano|spa)\b", "", RegexOptions.IgnoreCase);
+
+            return term;
+        }
+    }
+}

--- a/src/NzbDrone.Core/Indexers/Definitions/DivxTotal/DivxTotalSeriesParser.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/DivxTotal/DivxTotalSeriesParser.cs
@@ -1,0 +1,125 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Net;
+using System.Text.RegularExpressions;
+using AngleSharp.Dom;
+using AngleSharp.Html.Parser;
+using NzbDrone.Core.Indexers.Exceptions;
+using NzbDrone.Core.Parser.Model;
+
+namespace NzbDrone.Core.Indexers.Definitions.DivxTotal
+{
+    public class DivxTotalSeriesParser : IParseIndexerResponse
+    {
+        private const string DownloadLink = "/download_tt.php";
+        private readonly DivxTotalSettings _settings;
+        private readonly IndexerCapabilitiesCategories _categories;
+
+        public Action<IDictionary<string, string>, DateTime?> CookiesUpdater { get; set; }
+
+        public DivxTotalSeriesParser(DivxTotalSettings settings, IndexerCapabilitiesCategories categories)
+        {
+            _settings = settings;
+            _categories = categories;
+        }
+
+        public IList<ReleaseInfo> ParseResponse(IndexerResponse indexerResponse)
+        {
+            if (indexerResponse.HttpResponse.StatusCode != HttpStatusCode.OK)
+            {
+                throw new IndexerException(indexerResponse, $"Anidex search returned unexpected result. Expected 200 OK but got {indexerResponse.HttpResponse.StatusCode}.");
+            }
+
+            var releaseInfos = new List<ReleaseInfo>();
+
+            var parser = new HtmlParser();
+            using var dom = parser.ParseDocument(indexerResponse.Content);
+            var detailsStr = indexerResponse.HttpRequest.Url.ToString();
+            var cat = detailsStr.Split("/")[3];
+
+            var infoDiv = dom.QuerySelector(".panel-body>.row>.col-lg-7");
+            var publishDateContainer = infoDiv.QuerySelectorAll(".info-item")[1];
+            var publishDateStr = publishDateContainer.QuerySelectorAll("p")[1].TextContent.Trim();
+            var publishDate = TryToParseDate(publishDateStr, DateTime.Now);
+
+            var tables = dom.QuerySelectorAll("table.rwd-table");
+            foreach (var table in tables)
+            {
+                var rows = table.QuerySelectorAll("tbody > tr");
+                foreach (var row in rows)
+                {
+                    var anchor = row.QuerySelector("a");
+                    var episodeTitle = anchor.TextContent.Trim();
+
+                    // Convert the title to Scene format
+                    episodeTitle = ParseDivxTotalSeriesTitle(episodeTitle);
+
+                    var downloadLink = GetDownloadLink(row);
+
+                    releaseInfos.Add(GenerateRelease(episodeTitle, detailsStr, downloadLink, cat, publishDate, DivxTotalFizeSizes.Series));
+                }
+            }
+
+            return releaseInfos.ToArray();
+        }
+
+        private ReleaseInfo GenerateRelease(string title, string detailsStr, string downloadLink, string cat, DateTime publishDate, long size)
+        {
+            var release = new ReleaseInfo
+            {
+                Title = title,
+                InfoUrl = detailsStr,
+                DownloadUrl = downloadLink,
+                Guid = downloadLink,
+                Categories = _categories.MapTrackerCatToNewznab(cat),
+                PublishDate = publishDate,
+                Size = size,
+                Files = 1,
+            };
+            return release;
+        }
+
+        private static string ParseDivxTotalSeriesTitle(string episodeTitle)
+        {
+            // episodeTitle = American Horror Story6x04
+            var newTitle = episodeTitle;
+            try
+            {
+                var r = new Regex("(([0-9]+)x([0-9]+)[^0-9]*)$", RegexOptions.IgnoreCase);
+                var m = r.Match(newTitle);
+                if (m.Success)
+                {
+                    var season = "S" + m.Groups[2].Value.PadLeft(2, '0');
+                    var episode = "E" + m.Groups[3].Value.PadLeft(2, '0');
+                    newTitle = newTitle.Replace(m.Groups[1].Value, " " + season + episode);
+                }
+            }
+            catch (Exception e)
+            {
+                Console.WriteLine(e);
+                throw;
+            }
+
+            newTitle += " SPANISH SDTV XviD";
+
+            // return American Horror Story S06E04 SPANISH SDTV XviD
+            return newTitle;
+        }
+
+        private static DateTime TryToParseDate(string dateToParse, DateTime dateDefault)
+        {
+            try
+            {
+                return DateTime.ParseExact(dateToParse, "dd-MM-yyyy", CultureInfo.InvariantCulture);
+            }
+            catch
+            {
+                return dateDefault;
+            }
+        }
+
+        private static string GetDownloadLink(IElement dom) =>
+            dom.QuerySelector($"a[href*=\"{DownloadLink}\"]")?.GetAttribute("href");
+    }
+}

--- a/src/NzbDrone.Core/Indexers/Definitions/DivxTotal/DivxTotalSettings.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/DivxTotal/DivxTotalSettings.cs
@@ -1,0 +1,30 @@
+using NzbDrone.Core.Indexers.Settings;
+
+namespace NzbDrone.Core.Indexers.Definitions.DivxTotal
+{
+    public class DivxTotalSettings : NoAuthTorrentBaseSettings
+    {
+        public DivxTotalSettings()
+        {
+        }
+    }
+
+    internal static class DivxTotalCategories
+    {
+        public static string Peliculas => "peliculas";
+        public static string PeliculasHd => "peliculas-hd";
+        public static string Peliculas3D => "peliculas-3-d";
+        public static string PeliculasDvdr => "peliculas-dvdr";
+        public static string Series => "series";
+        public static string Programas => "programas";
+        public static string Otros => "otros";
+    }
+
+    internal static class DivxTotalFizeSizes
+    {
+        public static long Peliculas => 2147483648; // 2 GB
+        public static long PeliculasDvdr => 5368709120; // 5 GB
+        public static long Series => 536870912; // 512 MB
+        public static long Otros => 536870912; // 512 MB
+    }
+}


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Adds the DivxTotal indexer for Spanish community.
This implementation is a ripoff from the [Jackett](https://github.com/Jackett/Jackett/blob/master/src/Jackett.Common/Indexers/Definitions/DivxTotal.cs) one with the slight difference that filtering for series will actually try and search only series. Everything else is pretty much the same.

#### Todos
- [ ] Tests
- [ ] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [ ] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes #XXXX